### PR TITLE
fix: asc page title

### DIFF
--- a/afterschoolchess.html
+++ b/afterschoolchess.html
@@ -18,9 +18,9 @@
             onload="this.onload=null;this.rel='stylesheet'"
         >
         <!-- </link> -->
-        <title>BC Junior Chess Rapid | British Columbia Junior Chess Association</title>
-        <meta property="og:title" content="BC Junior Chess Rapid | British Columbia Junior Chess Association">
-        <meta name="twitter:title" content="BC Junior Chess Rapid | British Columbia Junior Chess Association">
+        <title>After School Chess Program | British Columbia Junior Chess Association</title>
+        <meta property="og:title" content="After School Chess Program | British Columbia Junior Chess Association">
+        <meta name="twitter:title" content="After School Chess Program | British Columbia Junior Chess Association">
         <meta name="description" content="View upcoming events happening in BC's greatest high school chess organization.">
         <meta property="og:description" content="View upcoming events happening in BC's greatest high school chess organization.">
         <meta name="twitter:description" content="View upcoming events happening in BC's greatest high school chess organization.">


### PR DESCRIPTION
Updating the after school chess page because the title of the page said BC Junior Chess Rapid. Changing it to say After School Chess Program. 